### PR TITLE
Changing the login example require in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ To do so, from your project directory type:
 As you can see below, it is very simple to login and acquire an OAuth token.
 
 ```javascript
-    var tjs = require('TeslaJS');
+    var tjs = require('teslajs');
 
     var username = "<your MyTesla email>";
     var password = "<your MyTesla password>";


### PR DESCRIPTION
Changing the login example require in the README. It was "TeslaJS" which would cause a "cannot find module 'TeslaJS'" as the module's name is "teslajs"