### PR TITLE
Updated openTrunk for 2018.10.4 software

### DIFF
--- a/TeslaJS.js
+++ b/TeslaJS.js
@@ -1189,29 +1189,29 @@ exports.remoteStart = function remoteStartDrive(options, password, callback) {
 exports.remoteStartAsync = Promise.denodeify(exports.remoteStart);
 
 //=====================
-// Truns/Frunk constants
+// Trunk/Frunk constants
 //=====================
 
 /**   
  * @global   
  * @default  
  */
-exports.FRUNK = "frunk";
+exports.FRUNK = "front";
 /**   
  * @global   
  * @default  
  */
-exports.TRUNK = "trunk";
+exports.TRUNK = "rear";
 
 /**
  * Open the trunk/frunk
  * @param {optionsType} options - options object
- * @param {string} which - one of "trunk", "frunk"
+ * @param {string} which - FRUNK or TRUNK constant
  * @param {nodeBack} callback - Node-style callback
  * @returns {object} result
  */
 exports.openTrunk = function openTrunk(options, which, callback) {
-    post_command(options, "command/trunk_open", { which_trunk: which }, callback);
+    post_command(options, "command/actuate_trunk", { which_trunk: which }, callback);
 }
 
 /**


### PR DESCRIPTION
Changes proposed in this pull request:
* Changed `FRUNK` constant to "front" and `TRUNK` constant to "rear"
* Changed URL used by `openTrunk` method which, to my knowledge, hasn't worked in quite some time

Tested with my own car and it does in fact open and close the trunk.

I didn't update any docs since the method was already documented (although non-functional).