### PR TITLE
Fix casing on `require` call

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ To do so, from your project directory type:
 As you can see below, it is very simple to login and acquire an OAuth token.
 
 ```javascript
-    var tjs = require('TeslaJS');
+    var tjs = require('teslajs');
 
     var username = "<your MyTesla email>";
     var password = "<your MyTesla password>";


### PR DESCRIPTION
(For copy-pasters like myself)

Calling `require('TeslaJS')` will work on MacOS and possibly Windows boxes where file systems are case-insensitive, however this will break on case-sensitive systems like Linux!

And it's important to catch this early - for instance I just published a module that used `require('TeslaJS')` and worked on my dev machine, then installed it on a linux system which crashed.
