### PR TITLE
Fixed setChargeLimit function

### DIFF
--- a/teslajs.js
+++ b/teslajs.js
@@ -1281,7 +1281,7 @@ exports.CHARGE_RANGE    = 100;
  * @returns {object} result
  */
 exports.setChargeLimit = function setChargeLimit(options, amt, callback) {
-    amt = clamp(amt, exports.CHARGE_STANDARD, exports.CHARGE_RANGE);
+    amt = clamp(amt, exports.CHARGE_STORAGE, exports.CHARGE_RANGE);
     post_command(options, "command/set_charge_limit", { percent: amt }, callback);
 }
 


### PR DESCRIPTION

Fixes # setChargeLimit previously would clamp values between CHARGE_STANDARD and CHARGE_RANGE, this would result in numbers from the setChargeLimit being isolated from 90 to 100. By changing the lower clamping liit to CHARGE_STORAGE, you can set the charging limit from anywhere from 50 to 100 percent.
Changes proposed in this pull request:
Changes the lower clamping limit in the setChargeLimit from CHARGE_STANDARD to CHARGE_STORAGE
