### PR TITLE
Report actual error when GET call parsing fails

### DIFF
--- a/teslajs.js
+++ b/teslajs.js
@@ -600,6 +600,7 @@ function get_command(options, command, callback) {
             callback(null, body);
         } catch (e) {
             log(API_ERR_LEVEL, 'Error parsing GET call response');
+            log(API_ERR_LEVEL, e);
             callback(e, null);
         }
 


### PR DESCRIPTION
When there is a user error in the callback, a generic error is reported, making it difficult to identify the issue. The patch also logs the actual error that occurred.

Fixes # .

Changes proposed in this pull request:
*
*
*

