### PR TITLE
add solar apis

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1686,3 +1686,29 @@ This models the streaming API interface.
             {
                 "result": "['elevation', 'est_heading', 'est_lat', 'est_lng', 'est_range', 'heading', 'odometer', 'power', 'range', 'shift_state', 'speed', 'soc']"            
             }
+
+## Get Current Solar Usage [GET /api/1/energy_sites/{site_id}/live_status]
+
+Get solar live status.
+
++ Request
+
+    + Headers
+
+            Authorization: Bearer {access_token}
+
++ Parameters
+
+    + site_id: `1` (number) - The id of the Vehicle.
+
++ Response 200 (application/json)
+
+    + Body
+
+            {
+              "response": {
+                "solar_power": 1000,
+                "load_power": 750,
+                "grid_power": 250
+              }
+            } 

--- a/teslajs.js
+++ b/teslajs.js
@@ -1759,6 +1759,122 @@ exports.homelink = function homelink(options, lat, long, token, callback) {
  */
 exports.homelinkAsync = Promise.denodeify(exports.homelink);
 
+/**
+ * Return list of products
+ * @function products
+ * @param {optionsType} options - options object
+ * @param {nodeBack} callback - Node-style callback
+ * @returns {Vehicles[]} array of products JSON data
+ */
+exports.products = function products(options, callback) {
+    log(API_CALL_LEVEL, "TeslaJS.products()");
+
+    callback =
+      callback ||
+      function(err, products) {
+        /* do nothing! */
+      };
+
+    var req = {
+      method: "GET",
+      url: portalBaseURI + "/api/1/products",
+      headers: {
+        Authorization: "Bearer " + options.authToken,
+        "Content-Type": "application/json; charset=utf-8"
+      }
+    };
+
+    log(API_REQUEST_LEVEL, "\nRequest: " + JSON.stringify(req));
+
+    request(req, function(error, response, body) {
+      if (error) {
+        log(API_ERR_LEVEL, error);
+        return callback(error, null);
+      }
+
+      if (response.statusCode != 200) {
+        return callback(response.statusMessage, null);
+      }
+
+      log(API_BODY_LEVEL, "\nBody: " + JSON.stringify(body));
+      log(API_RESPONSE_LEVEL, "\nResponse: " + JSON.stringify(response));
+
+      try {
+        body = body.response;
+
+        callback(null, body);
+      } catch (e) {
+        log(API_ERR_LEVEL, "Error parsing products response");
+        callback(e, null);
+      }
+
+      log(API_RETURN_LEVEL, "\nGET request: " + "/products" + " completed.");
+    });
+  };
+
+/**
+ * Return live status from solar installation
+ * @function solarStatus
+ * @param {optionsType} options - options object
+ * @param {nodeBack} callback - Node-style callback
+ * @returns {Vehicles[]} array of solarStatus JSON data
+ */
+exports.solarStatus = function solarStatus(options, callback) {
+    log(API_CALL_LEVEL, "TeslaJS.solarStatus()");
+
+    callback =
+      callback ||
+      function(err, solarStatus) {
+        /* do nothing! */
+      };
+
+    var req = {
+      method: "GET",
+      url: portalBaseURI + "/api/1/energy_sites/" + options.siteId + "/live_status",
+      headers: {
+        Authorization: "Bearer " + options.authToken,
+        "Content-Type": "application/json; charset=utf-8"
+      }
+    };
+
+    log(API_REQUEST_LEVEL, "\nRequest: " + JSON.stringify(req));
+
+    request(req, function(error, response, body) {
+      if (error) {
+        log(API_ERR_LEVEL, error);
+        return callback(error, null);
+      }
+
+      if (response.statusCode != 200) {
+        return callback(response.statusMessage, null);
+      }
+
+      log(API_BODY_LEVEL, "\nBody: " + JSON.stringify(body));
+      log(API_RESPONSE_LEVEL, "\nResponse: " + JSON.stringify(response));
+
+      try {
+        body = body.response;
+
+        callback(null, body);
+      } catch (e) {
+        log(API_ERR_LEVEL, "Error parsing solarStatus response");
+        callback(e, null);
+      }
+
+      log(API_RETURN_LEVEL, "\nGET request: " + "/solarStatus" + " completed.");
+    });
+  };
+
+  /**
+   * Return solar status information
+   * @function solarStatusAsync
+   * @param {optionsType} options - options object
+   * @param {nodeBack} callback - Node-style callback
+   * @returns {Promise} array of solar JSON data
+   */
+  exports.solarStatusAsync = Promise.denodeify(exports.solarStatus);
+
+
 /*
 //
 // [Alpha impl] Not yet supported

--- a/test/test.js
+++ b/test/test.js
@@ -1663,3 +1663,24 @@ describe('TeslaJS', function () {
 	    });
 	});	
 });
+
+describe("#getSolarStatus()", function() {
+	it("should return the current solar production", function(done) {
+	  tjs.solarStatus({ siteId: 1 }, function(err, result) {
+		assert.equal(1000, result.solar_power);
+		done();
+	  });
+	});
+	it("should return the current power consumption", function(done) {
+	  tjs.solarStatus({ siteId: 1 }, function(err, result) {
+		assert.equal(750, result.load_power);
+		done();
+	  });
+	});
+	it("should return the current net grid power", function(done) {
+	  tjs.solarStatus({ siteId: 1 }, function(err, result) {
+		assert.equal(250, result.grid_power);
+		done();
+	  });
+	});
+  }); 


### PR DESCRIPTION
Fixes https://github.com/mseminatore/TeslaJS/issues/134

Changes proposed in this pull request:
* add products api to get a list of all registered products and their energy site IDs
* add solarStatus api to get current solar usage in terms of consumption and production 
* add unit tests

I'm using this in a prometheus exporter which tracks solar usage over time so it can be visualized in Grafana.  Not yet released.  Will post here when it's ready.

