### PR TITLE
Fixed header per timdorr suggestion

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -3,7 +3,7 @@
 var request = require('request').defaults({
     headers: {
         "x-tesla-user-agent": "TeslaApp/3.10.8-421/adff2e065/android/8.1.0",
-        "user-agent": "Mozilla/5.0 (Linux; Android 8.1.0; Pixel XL Build/OPM4.171019.021.D1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36",
+        "user-agent": "TeslaApp",
         "x-requested-with": "com.teslamotors.tesla"
     },
     gzip: true,


### PR DESCRIPTION
As found in the authentication documentation
https://tesla-api.timdorr.com/api-basics/authentication

Changes proposed in this pull request:
* changed the user-agent header per timdorr documentation that say "Avoid setting a User-Agent header that looks like a browser (such as Chrome or Safari). The SSO service has protections in place that will require executing JavaScript if a browser-like user agent is detected."

Testing done on February 13th, 2021.  I tested the original code and it fails.  This was with an actual Tesla account with a Tesla Model 3 on the account.  The testing was done with the Tesla account set up both without MFA configured and with MFA configured.  With the user-agent set to "Mozilla/5.0 (Linux; Android 8.1.0; Pixel XL Build/OPM..." the API calls for both configurations (w/wo MFA) failed.
After the user-agent was changed to something else, in this case "TeslaApp" the API worked fine for both cases.

npm test in the pull request branch came up with the same results as npm test in the original master branch.

