### PR TITLE
Add vehicleById and vehicleByIdAsync function 

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ setPortalBaseURI() | sets the server for testing, pass null to reset
 login() | authenticate with Tesla servers and retrieve the OAuth token
 logout() | delete the current OAuth token
 vehicle() | return information on the requested vehicle defined by `carIndex` in `options`
+vehicleById() | return information on the requested vehicle defined by `vehicleID` in `options`
 vehicles() | return information and option data for all vehicles
 getModel(vehicle) | returns the Tesla model as a string from vehicle object
 getPaintColor(vehicle) | returns the paint color as a string from vehicle object

--- a/teslajs.js
+++ b/teslajs.js
@@ -520,6 +520,62 @@ exports.vehicle = function vehicle(options, callback) {
 exports.vehicleAsync = Promise.denodeify(exports.vehicle);
 
 /**
+ * Return vehicle information on the requested vehicle. Uses options.vehicleID
+ * to determine which vehicle to fetch data for.
+ * @function vehicleById
+ * @param {optionsType} options - options object
+ * @param {nodeBack} callback - Node-style callback
+ * @returns {Vehicle} vehicle JSON data
+ */
+ exports.vehicleById = function vehicle(options, callback) {
+  log(API_CALL_LEVEL, "TeslaJS.vehicleById()");
+
+  callback = callback || function (err, vehicle) { /* do nothing! */ }
+
+  var req = {
+      method: 'GET',
+      url: portalBaseURI + '/api/1/vehicles/' + options.vehicleID,
+      headers: { Authorization: "Bearer " + options.authToken, 'Content-Type': 'application/json; charset=utf-8' }
+  };
+
+  log(API_REQUEST_LEVEL, "\nRequest: " + JSON.stringify(req));
+
+  request(req, function (error, response, body) {
+      if (error) {
+          log(API_ERR_LEVEL, error);
+          return callback(error, null);
+      }
+
+      if (response.statusCode != 200) {
+          return callback(response.statusMessage, null);
+      }
+
+      log(API_BODY_LEVEL, "\nBody: " + JSON.stringify(body));
+      log(API_RESPONSE_LEVEL, "\nResponse: " + JSON.stringify(response));
+
+      try {
+        body = body.response;
+        
+        callback(null, body);
+    } catch (e) {
+        log(API_ERR_LEVEL, 'Error parsing vehicle response');
+        callback(e, null);
+    }
+
+      log(API_RETURN_LEVEL, "\nGET request: " + "/vehicles/" + options.vehicleID + " completed.");
+  });
+}
+
+/**
+* Return vehicle information on the requested vehicle. Uses options.vehicleID
+* to determine which vehicle to fetch data for.
+* @function vehicleByIdAsync
+* @param {optionsType} options - options object
+* @returns {Promise} vehicle JSON data
+*/
+exports.vehicleByIdAsync = Promise.denodeify(exports.vehicleById);
+
+/**
  * Return vehicle information on ALL vehicles
  * @function vehicles
  * @param {optionsType} options - options object

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,7 @@ function failure(msg) {
 }
 
 describe('TeslaJS', function () {
-	var options = {authToken: "abc123", vehicleID: "1234", vehicle_id: "1", token: "1", username: user, password: pass};
+	var options = {authToken: "abc123", vehicleID: "1234567890", vehicle_id: "1", token: "1", username: user, password: pass};
     this.timeout(7500);
 
     describe('#getStreamingBaseURI()', function () {
@@ -386,6 +386,31 @@ describe('TeslaJS', function () {
 	        });
 	    });
 	});
+
+    describe('#vehicleById()', function () {
+        it('should succeed getting the vehicle', function (done) {
+            tjs.vehicleById(options, function (err, vehicle) {
+                if (vehicle.vehicle_id) {
+                    done();
+                } else {
+                    done(vehicle.response.statusMessage);
+                }
+            });
+        });
+
+        it('should succeed with no callback', function (done) {
+            tjs.vehicleById(options);
+            done();
+        });
+    });
+
+    describe('#vehicleByIdAsync()', function () {
+        it('should succeed getting the vehicle', function () {
+            return tjs.vehicleByIdAsync(options).then(function (result) {
+                assert(result.vehicle_id);
+            });
+        });
+    });
 
     describe('#vehicleConfig()', function () {
         it('should return vehicle config', function (done) {


### PR DESCRIPTION
These functions use `options.vehicleID` to make a call to fetch a specific
Vehicle from the Tesla API, rather than fetching all vehicles and using
`carIndex` to select the requested vehicle.

Fixes #273 
