### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,6 @@ To download and install the library and all of its dependencies to a local
 project directory use the following:
 
     npm install teslajs
-
-If you are building an npm package that depends upon this library then you 
-will want to use the **--save** parameter in order to update the 
-**package.json** file for your project. For example:
-
-    npm install teslajs --save
     
 If you prefer to download and install the library globally for all future 
 node projects you may use:


### PR DESCRIPTION
Suggestion to remove the section on `npm install teslajs --save`. I had never heard of the `--save` flag before, and it looks like this is now the default npm behavior: https://stackoverflow.com/questions/19578796/what-is-the-save-option-for-npm-install

Fixes # .

Changes proposed in this pull request:
*
*
*

