### PR TITLE
Update teslajs.js with getPaintColor Error handling

### DIFF
--- a/teslajs.js
+++ b/teslajs.js
@@ -304,6 +304,9 @@ exports.getPaintColor = function getPaintColor(vehicle) {
         "PPTI": "titanium",
         "PMTG": "metallic grey"   // dolphin grey
     };
+    if (!vehicle || !vehicle.option_codes) {
+        return "unknown";
+    }
 
     var paintColor = vehicle.option_codes.match(/PBCW|PBSB|PMAB|PMBL|PMMB|PMMR|PPMR|PMNG|PMSG|PMSS|PPSB|PPSR|PPSW|PPTI|PMTG/);
 


### PR DESCRIPTION
Fixes #Tesla removing Option_codes.

Changes proposed in this pull request:
* Added a conditional to see if either vehicle or vehicle.option_codes exists, if one is true, return "unknown"
* Tesla have removed option_codes from some cars through this method so it makes sense to add some error handling eventualities 

